### PR TITLE
Remove runtime config for ignoring custom elements

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -7,9 +7,6 @@ import router from './router'
 //createApp(App).use(router).mount('#app')
 
 const app = createApp(App)
-//runtime config to ignore bdl elements, non-runtime config somewhere to ...
-app.config.isCustomElement = (tag) => tag.startsWith('bdl-');
-app.config.ignoredElements = ['bdl-fmi','bdl-chartjs-time','bdl-range']
 app.use(router).mount('#app')
 
 /*


### PR DESCRIPTION
That config is unnecessary since vue-loader is configured at compile time to ignore `bdi-*` elements.